### PR TITLE
Make etherlime a devDependency, do not rebuild contracts in docker.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,3 @@ node_modules
 .vscode
 demo
 .git
-build

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ demo
 .etherlime-store
 store
 .env
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN chown -R node /home/node/
 USER node
 WORKDIR /home/node
 RUN npm ci
-RUN npm run build-contracts
+RUN npm prune --production
 
 FROM ubuntu:16.04
 ARG NODE_VERSION="v12.16.1"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "system-tests": "mocha test/system/engine-and-editor-api.js --exit",
     "contract-tests": "npm run build-contracts && etherlime test --solcVersion=0.4.24 test/contracts",
     "test": "npm run unit-tests && npm run integration-tests && npm run script-tests && npm run contract-tests",
-    "preinstall": "node scripts/fix_package_lock.js || true"
+    "preinstall": "node scripts/fix_package_lock.js || true",
+    "prepare": "if [[ ${NODE_ENV} != \"production\" ]]; then npm run build-contracts && npm run flatten; fi"
   },
   "author": "Streamr Network AG",
   "license": "AGPL-3.0",


### PR DESCRIPTION
This simply moves `etherlime` from `dependencies` to `devDependencies`. The subsequent `npm install` generated some shift in the package-lock, but I don't see another way to perform this move and update the package-lock to just add the `"dev": true` flags. 🤷‍♀

Related to https://github.com/streamr-dev/streamr-community-products/pull/36 which sets CPS to only install production dependencies for the Docker env. 

Since we're [checking in the built contracts](https://github.com/streamr-dev/streamr-community-products/tree/e9208d18292a7a388bb22cd78a3167559b55e898/build) anyway, it probably doesn't make sense to re-build them for Docker, especially since IIUC we don't rebuild the contracts for the Travis CI tests.