### PR TITLE
Fix permissions granting

### DIFF
--- a/scripts/check_dataunion.js
+++ b/scripts/check_dataunion.js
@@ -126,11 +126,19 @@ async function start() {
         try {
             const perms = await stream.getPermissions()
             log(`  Permissions: ${JSON.stringify(perms)}`)
-            const nodeWritePerm = perms.find(p => p.operation === "write" && p.user === streamrNodeAddress)
-            if (nodeWritePerm) {
-                log("  Streamr node has write permission")
+
+            const nodePublishPerm = perms.find(p => p.operation === "stream_publish" && p.user === streamrNodeAddress)
+            if (nodePublishPerm) {
+                log("  Streamr node has stream_publish permission")
             } else {
-                log("!!! STREAMR NODE NEEDS WRITE PERMISSION, otherwise joins and parts won't work !!!")
+                log("!!! STREAMR NODE NEEDS stream_publish permission, otherwise joins and parts won't work !!!")
+            }
+
+            const nodeGetPerm = perms.find(p => p.operation === "stream_get" && p.user === streamrNodeAddress)
+            if (nodeGetPerm) {
+                log("  Streamr node has stream_get permission")
+            } else {
+                log("!!! STREAMR NODE NEEDS stream_get permission, otherwise joins and parts won't work !!!")
             }
         } catch (e) {
             if (e.message.includes("403")) {

--- a/src/utils/deployContract.js
+++ b/src/utils/deployContract.js
@@ -42,11 +42,17 @@ async function deployContract(wallet, operatorAddress, tokenAddress, streamrNode
     const stream = await client.createStream({ name: joinPartStreamName })
 
     // every watcher should be able to read joins and parts in order to sync the state
-    const res1 = await stream.grantPermission("read", null)
-    log("Grant public read", JSON.stringify(res1))
+    const res1 = [
+        await stream.grantPermission("stream_get", null),
+        await stream.grantPermission("stream_subscribe", null),
+    ]
+    log("Grant public get & subscribe", JSON.stringify(res1))
 
     // streamrNode must be able to handle accepted JoinRequests
-    const res2 = await stream.grantPermission("write", streamrNodeAddress)
+    const res2 = [
+        await stream.grantPermission("stream_get", streamrNodeAddress),
+        await stream.grantPermission("stream_publish", streamrNodeAddress),
+    ]
     log("Grant E&E write", JSON.stringify(res2))
 
     const options = {}


### PR DESCRIPTION
Updated the outdated permission granting in tests to match the new permissions.

Opening this as a draft PR: The permission-related errors are now gone, but still getting the following (unrelated?) errors in integration tests. Will need to hand this over to @isentropy to continue from.

```
  Exit everyone script
    1) successfully exits everyone using one address
    2) successfully exits everyone using many addresses in parallel


  0 passing (5s)
  2 pending
  2 failing

  1) Exit everyone script
       successfully exits everyone using one address:
     TypeError: Cannot read property '1' of undefined
      at Context.<anonymous> (test/scripts/exit_everyone.js:150:52)

  2) Exit everyone script
       successfully exits everyone using many addresses in parallel:
     TypeError: Cannot read property '1' of undefined
      at Context.<anonymous> (test/scripts/exit_everyone.js:193:52)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
```