### PR TITLE
Fix StreamrClient function naming

### DIFF
--- a/scripts/check_dataunion.js
+++ b/scripts/check_dataunion.js
@@ -77,8 +77,7 @@ async function start() {
     const client = new StreamrClient(opts)
 
     log("Data union stats from server")
-    //const stats = await client.getDataUnionStats(dataUnion.address)
-    const stats = await client.getCommunityStats(dataUnion.address)
+    const stats = await client.getDataUnionStats(dataUnion.address)
     log(`  Members: ${stats.memberCount.active} active / ${stats.memberCount.total} total`)
     log(`  Latest unfrozen block: ${stats.latestWithdrawableBlock.blockNumber} (${stats.latestWithdrawableBlock.memberCount} members)`)
     log(`  Total earnings received: ${formatEther(stats.totalEarnings)}`)

--- a/scripts/join_dataunion.js
+++ b/scripts/join_dataunion.js
@@ -55,8 +55,7 @@ async function start() {
 
     log(`secret: ${SECRET}`)
     log(`Adding https://streamr.com/api/v1/dataunions/${dataUnionAddress}/members/${memberAddress} ...`)
-    //const res = await client.joinDataUnion(dataUnionAddress, SECRET)
-    const res = await client.joinCommunity(dataUnionAddress, SECRET)
+    const res = await client.joinDataUnion(dataUnionAddress, SECRET)
 
     log(`dataUnion join sent, response: ${JSON.stringify(res)}`)
     log(`Network was ${JSON.stringify(network)}`)

--- a/test/system/demo-using-client.js
+++ b/test/system/demo-using-client.js
@@ -229,8 +229,7 @@ describe.skip("Data Union demo but through a running E&E instance", () => {
             await transferTx.wait(2)
 
             // check total revenue
-            //const res3 = await client.getDataUnionStats(dataUnion.address)
-            const res3 = await client.getCommunityStats(dataUnion.address)
+            const res3 = await client.getDataUnionStats(dataUnion.address)
             log(`   Total revenue: ${formatEther(res3.totalEarnings)}`)
         }
 


### PR DESCRIPTION
StreamrClient already uses DataUnion naming based on how it worked on production server (client version 4.1.0-beta.0)