### PR TITLE
Adds prefix to logs & error messages to timeouts.

### DIFF
--- a/src/operator.js
+++ b/src/operator.js
@@ -12,10 +12,11 @@ module.exports = class MonoplasmaOperator {
         this.wallet = wallet;
         this.watcher = new MonoplasmaWatcher(wallet.provider, joinPartChannel, store);
         this.lastSavedBlock = null;
+        this.log = debug("Streamr::dataunion::operator");
     }
     async start(config) {
         throwIfBadAddress(config.operatorAddress, "MonoplasmaOperator argument config.operatorAddress");
-        this.log = debug("Streamr::dataunion::operator::" + config.contractAddress);
+        this.log = this.log.extend(config.contractAddress);
         this.finalityWaitPeriodSeconds = config.finalityWaitPeriodSeconds || 1; // TODO: in production || 3600
         this.address = config.operatorAddress;
         this.gasPrice = config.gasPrice || 4000000000; // 4 gwei

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -27,11 +27,12 @@ module.exports = class MonoplasmaOperator {
         this.wallet = wallet
         this.watcher = new MonoplasmaWatcher(wallet.provider, joinPartChannel, store)
         this.lastSavedBlock = null
+        this.log = debug("Streamr::dataunion::operator")
     }
 
     async start(config) {
         throwIfBadAddress(config.operatorAddress, "MonoplasmaOperator argument config.operatorAddress")
-        this.log = debug("Streamr::dataunion::operator::" + config.contractAddress)
+        this.log = this.log.extend(config.contractAddress)
 
         this.finalityWaitPeriodSeconds = config.finalityWaitPeriodSeconds || 1 // TODO: in production || 3600
         this.address = config.operatorAddress

--- a/src/server.js
+++ b/src/server.js
@@ -98,6 +98,7 @@ module.exports = class DataUnionServer {
         const startAllTime = Date.now()
         await pAll(addresses.map((contractAddress) => () => {
             const startEventTime = Date.now()
+            this.log(`Playing back ${contractAddress} operator change event...`)
             return this.onOperatorChangedEventAt(contractAddress).catch((err) => {
                 // TODO: while developing, 404 for joinPartStream could just mean
                 //   mysql has been emptied by streamr-ganache docker not,
@@ -111,6 +112,7 @@ module.exports = class DataUnionServer {
                 numErrors++
             }).then(() => {
                 numComplete++
+                this.log(`Played back ${contractAddress} operator change event.`)
                 this.log(`Event ${numComplete} of ${total} processed in ${Date.now() - startEventTime}ms, ${Math.round((numComplete / total) * 100)}% complete.`)
             })
         }), { concurrency: 6 })

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -106,7 +106,7 @@ module.exports = class MonoplasmaWatcher extends EventEmitter {
         if (await this.store.hasLatestBlock()) {
             this.log("Getting latest block from store");
             lastBlock = await this.store.getLatestBlock();
-            this.log(`Got ${JSON.stringify(lastBlock)}`);
+            this.log("Got", lastBlock);
         }
         this.log(`Syncing Monoplasma state starting from block ${lastBlock.blockNumber} (t=${lastBlock.timestamp}) with ${lastBlock.members.length} members`);
         const playbackStartingTimestampSeconds = lastBlock.timestamp || lastBlock.blockNumber && await this.getBlockTimestamp(lastBlock.blockNumber) || 0;
@@ -130,10 +130,10 @@ module.exports = class MonoplasmaWatcher extends EventEmitter {
             const event = { type, addressList, timestamp: meta.messageId.timestamp };
             this.messageCache.push(event);
         });
+        this.channel.on("error", this.log);
         await this.channel.listen(playbackStartingTimestampMs);
         this.log(`Playing back ${this.messageCache.length} messages from joinPartStream`);
         // messages are now cached => do the Ethereum event playback, sync up this.plasma
-        this.channel.on("error", this.log);
         const currentBlock = await this.eth.getBlockNumber();
         this.state.lastPublishedBlock = await this.playbackUntilBlock(currentBlock, this.plasma);
         // for messages from now on: add to cache but also replay directly to "realtime plasma"

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -122,7 +122,7 @@ module.exports = class MonoplasmaWatcher extends EventEmitter {
         if (await this.store.hasLatestBlock()) {
             this.log("Getting latest block from store")
             lastBlock = await this.store.getLatestBlock()
-            this.log(`Got ${JSON.stringify(lastBlock)}`)
+            this.log("Got", lastBlock)
         }
         this.log(`Syncing Monoplasma state starting from block ${lastBlock.blockNumber} (t=${lastBlock.timestamp}) with ${lastBlock.members.length} members`)
         const playbackStartingTimestampSeconds = lastBlock.timestamp || lastBlock.blockNumber && await this.getBlockTimestamp(lastBlock.blockNumber) || 0
@@ -148,11 +148,11 @@ module.exports = class MonoplasmaWatcher extends EventEmitter {
             const event = { type, addressList, timestamp: meta.messageId.timestamp }
             this.messageCache.push(event)
         })
+        this.channel.on("error", this.log)
         await this.channel.listen(playbackStartingTimestampMs)
         this.log(`Playing back ${this.messageCache.length} messages from joinPartStream`)
 
         // messages are now cached => do the Ethereum event playback, sync up this.plasma
-        this.channel.on("error", this.log)
         const currentBlock = await this.eth.getBlockNumber()
         this.state.lastPublishedBlock = await this.playbackUntilBlock(currentBlock, this.plasma)
 


### PR DESCRIPTION
Changes I made to logging & timeout errors while on the debugging call today.
Mostly this just sets up prefixed logging so it's a bit clearer which community each log line belongs to, and removes inline `JSON.stringify` calls in favour of letting `debug` pretty-print objects. 